### PR TITLE
Feature/sn connect style survey

### DIFF
--- a/code/web/src/modules/crate/Item.js
+++ b/code/web/src/modules/crate/Item.js
@@ -14,6 +14,7 @@ import { white, grey2, black } from '../../ui/common/colors'
 // App Imports
 import { APP_URL } from '../../setup/config/env'
 import userRoutes from '../../setup/routes/user'
+import style from '../../setup/routes/style'
 import { messageShow, messageHide } from '../common/api/actions'
 import { create } from '../subscription/api/actions'
 
@@ -28,14 +29,22 @@ class Item extends PureComponent {
     }
   }
 
-  onClickSubscribe = (crateId) => {
+  handleClick = (crateId) => {
+    if (!this.props.user.style) {
+      this.props.history.push(style.survey.path)
+    } else {
+      this.subscribeUserToCrate(crateId)
+    }
+  }
+
+  subscribeUserToCrate = (crateId) => {
     this.setState({
       isLoading: true
     })
 
     this.props.messageShow('Subscribing, please wait...')
-
     this.props.create({ crateId })
+    
       .then(response => {
         if (response.data.errors && response.data.errors.length > 0) {
           this.props.messageShow(response.data.errors[0].message)
@@ -45,18 +54,18 @@ class Item extends PureComponent {
           this.props.history.push(userRoutes.subscriptions.path)
         }
       })
-      .catch(error => {
-        this.props.messageShow('There was some error subscribing to this crate. Please try again.')
+    .catch(error => {
+      this.props.messageShow('There was some error subscribing to this crate. Please try again.')
+    })
+    .then(() => {
+      this.setState({
+        isLoading: false
       })
-      .then(() => {
-        this.setState({
-          isLoading: false
-        })
 
-        window.setTimeout(() => {
-          this.props.messageHide()
-        }, 5000)
-      })
+      window.setTimeout(() => {
+        this.props.messageHide()
+      }, 5000)
+    })
   }
 
   render() {
@@ -77,7 +86,7 @@ class Item extends PureComponent {
           <p style={{ textAlign: 'center', marginTop: '1.5em', marginBottom: '1em' }}>
             <Button
               theme="primary"
-              onClick={this.onClickSubscribe.bind(this, id)}
+              onClick={this.handleClick.bind(this, id)}
               type="button"
               disabled={ isLoading }
             >

--- a/code/web/src/modules/crate/Item.js
+++ b/code/web/src/modules/crate/Item.js
@@ -14,7 +14,7 @@ import { white, grey2, black } from '../../ui/common/colors'
 // App Imports
 import { APP_URL } from '../../setup/config/env'
 import userRoutes from '../../setup/routes/user'
-import style from '../../setup/routes/style'
+import styleSurvey from '../../setup/routes/styleSurvey'
 import { messageShow, messageHide } from '../common/api/actions'
 import { create } from '../subscription/api/actions'
 
@@ -31,7 +31,7 @@ class Item extends PureComponent {
 
   handleClick = (crateId) => {
     if (!this.props.user.style) {
-      this.props.history.push(style.survey.path)
+      this.props.history.push(styleSurvey.survey.path)
     } else {
       this.subscribeUserToCrate(crateId)
     }

--- a/code/web/src/modules/user/api/state.js
+++ b/code/web/src/modules/user/api/state.js
@@ -18,6 +18,8 @@ export default (state = userInitialState, action) => {
         ...state,
         isAuthenticated: !isEmpty(action.user),
         details: action.user,
+        // temporary property, to be deleted when this property is added to the back end: 
+        style: null
       }
 
     case LOGIN_REQUEST:


### PR DESCRIPTION
#### What's this PR do?
- Adds logic to `Subscribe` button click to take user to survey if they have not already taken it:
     -  imports path to the survey
     - `handleClick` method is a helper function that will either route the user to the survey or invoke `subscribeUserToCrate()`
     - `subscribeUserToCrate` method has most of the original `onClickSubscribe` logic
- Rebased with Clickable survey and survey component branches 

#### Where should the reviewer start?
- Look at the file:`modules/crate/item`, and review the refactored methods

#### How should this be manually tested?
- Go to localhost:3000/crates and click the subscription button. You should be taken to the survey

#### Any background context you want to provide?

I added a `style: null` property to the user object in _'modules/user/api/state'_ so I could test the logic and functionality of the button click. Since the value is null, the survey will always be rendered when the `Subscribe` button is clicked.
The style property needs to be deleted once we connect the survey results with BE/FE.

#### What are the relevant tickets?
#34 
#### Screenshots (if appropriate)
n/a
#### Questions:
Any ideas of how to refactor the onClick methods any further?

#### Testing:
We've got an issue card for setting up a test for the subscribe button. It's still in the to-do list as I didn't get to it yet.
